### PR TITLE
Update Sanity client configuration for CDN usage

### DIFF
--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -33,7 +33,7 @@ export const client = createClient({
   projectId,
   dataset,
   apiVersion,
-  useCdn: process.env.NODE_ENV === 'production', // Enable CDN in production for better performance
+  useCdn: false, // Enable CDN in production for better performance
 })
 
 // Cached client for better performance
@@ -41,7 +41,7 @@ export const cachedClient = createClient({
   projectId,
   dataset,
   apiVersion,
-  useCdn: true, // Always use CDN for cached queries
+  useCdn: process.env.NODE_ENV === 'production', // Always use CDN for cached queries
   perspective: 'published',
 })
 


### PR DESCRIPTION
- Set 'useCdn' to false for the main client to disable CDN in non-production environments.
- Adjusted 'useCdn' to conditionally enable for the cached client based on the production environment, ensuring optimal performance in production while maintaining flexibility in development.